### PR TITLE
Access to the app with required authentication

### DIFF
--- a/server.py
+++ b/server.py
@@ -48,8 +48,7 @@ app.wsgi_app = TenantPrefixMiddleware(app.wsgi_app)
 app.session_interface = TenantSessionInterface(os.environ)
 
 def auth_path_prefix():
-    path = app.session_interface.tenant_path_prefix() + AUTH_PATH
-    return path.replace("//", "/")
+    return app.session_interface.tenant_path_prefix().rstrip("/") + "/" + AUTH_PATH.lstrip("/")
 
 @app.before_request
 @jwt_optional

--- a/server.py
+++ b/server.py
@@ -10,7 +10,7 @@ from qwc_services_core.tenant_handler import TenantHandler, TenantPrefixMiddlewa
 from qwc2_viewer import QWC2Viewer
 
 AUTH_PATH = os.environ.get('AUTH_PATH', '/auth')
-AUTH_REQUIRED = os.environ.get('AUTH_REQUIRED', False)
+AUTH_REQUIRED = os.environ.get('AUTH_REQUIRED', '0') not in [0, "0", "False", "FALSE"]
 
 # Flask application
 app = Flask(__name__)


### PR DESCRIPTION
Hello @pka 

I need to access to the application only when user is logged in. I used what you have done in https://github.com/qwc-services/qwc-admin-gui/commit/fb5955d708a943c74e0373f606d3e13672604dc7 to test if user is logged. Otherwise, user is redirected to authentication page.

Also, when no `TENANT_HEADER` is set in configuration, there is an error that occurs because `//` does'nt work in url. I replace it with a simple `/`. It is the same in [qwc-admin-gui](https://github.com/qwc-services/qwc-admin-gui/).

Thanks