### PR TITLE
Add documentation for wildcard in background layer permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ Example:
 
 * `viewer_tasks`: permitted menu items if any are restricted
 * `wms_services`: permitted WMS services, layers and print templates
-* `background_layers`: permitted background layers
+* `background_layers`: permitted background layers (use the wildcard string "*" to allow all background layers)
 * `data_datasets`: permitted datasets for editing
 
 In this example, the _Raster Export_ map tool will only be visible for users with the role `demo`.


### PR DESCRIPTION
Follow-up to #28

Since https://qwc-services.github.io/master/configuration/ResourcesPermissions/ refers to the READMEs of the different qwc-services repositories, I added the documentation in this place.