### PR TITLE
Allow loading a visibility preset ("vp") as default param

### DIFF
--- a/src/qwc2_viewer.py
+++ b/src/qwc2_viewer.py
@@ -104,6 +104,7 @@ class QWC2Viewer:
         # if params are empty, check if there are default params
         # configured in user_info_fields, and redirect if that is the case
         if not params.get('t') and not params.get('k') and not params.get('bk') \
+            and not params.get('vp') \
             and isinstance(identity, dict) and self.db_url \
         :
             db = db_engine.db_engine(self.db_url)


### PR DESCRIPTION
Relates to https://github.com/qgis/qwc2/pull/526
To load visibility presets stored as default params on startup this line has to be added. Otherwise this results in a redirection loop.